### PR TITLE
Added SSL Generation to Nginx conf

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -12,6 +12,17 @@ RUN apk update \
     && apk add --no-cache bash \
     && adduser -D -H -u 1000 -s /bin/bash www-data
 
+# install openssl
+RUN apk add --no-cache openssl
+
+# create a folder for the keys
+RUN mkdir /etc/nginx/ssl 2> /dev/null
+
+# generate the keys for localhost
+RUN openssl genrsa -out "/etc/nginx/ssl/localhost.key" 2048 \
+    && openssl req -new -key "/etc/nginx/ssl/localhost.key" -out "/etc/nginx/ssl/localhost.csr" -subj "/CN=localhost/O=HeyOrca/C=CA" \
+    && openssl x509 -req -days 365 -in "/etc/nginx/ssl/localhost.csr" -signkey "/etc/nginx/ssl/localhost.key" -out "/etc/nginx/ssl/localhost.crt"
+
 # Set upstream conf and remove the default conf
 RUN echo "upstream php-upstream { server ${PHP_UPSTREAM_CONTAINER}:${PHP_UPSTREAM_PORT}; }" > /etc/nginx/conf.d/upstream.conf \
     && rm /etc/nginx/conf.d/default.conf

--- a/nginx/sites/default.conf
+++ b/nginx/sites/default.conf
@@ -2,10 +2,14 @@ server {
 
     listen 80 default_server;
     listen [::]:80 default_server ipv6only=on;
+    listen 443 ssl;
 
     server_name localhost;
     root /var/www/public;
     index index.php index.html index.htm;
+
+    ssl_certificate /etc/nginx/ssl/localhost.crt;
+    ssl_certificate_key /etc/nginx/ssl/localhost.key;
 
     location / {
          try_files $uri $uri/ /index.php$is_args$args;


### PR DESCRIPTION
Added SSL Generation to Nginx conf
    
Nginx Dockerfile now generates a self signed cert for localhost. The nginx/sites/default.conf now serves over HTTPS using this cert.

TO TEST:
- docker-compose up --build
- try connecting to your application being served by the nginx container over HTTPS using whatever HTTPS port you've configured

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [] I've read the [Contribution Guide](http://laradock.io/contributing).
- [] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [] I enjoyed my time contributing and making developer's life easier :)
